### PR TITLE
feat: Add LRN opset 13 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# VS Code project settings
+.vscode
+
 # mkdocs documentation
 /site
 

--- a/onnx2torch/node_converters/__init__.py
+++ b/onnx2torch/node_converters/__init__.py
@@ -19,6 +19,7 @@ from onnx2torch.node_converters.gemm import *
 from onnx2torch.node_converters.global_average_pool import *
 from onnx2torch.node_converters.identity import *
 from onnx2torch.node_converters.logical import *
+from onnx2torch.node_converters.lrn import *
 from onnx2torch.node_converters.matmul import *
 from onnx2torch.node_converters.max_pool import *
 from onnx2torch.node_converters.mean import *

--- a/onnx2torch/node_converters/lrn.py
+++ b/onnx2torch/node_converters/lrn.py
@@ -8,12 +8,13 @@ from onnx2torch.onnx_node import OnnxNode
 from onnx2torch.utils.common import OperationConverterResult
 from onnx2torch.utils.common import onnx_mapping_from_node
 
+
 @add_converter(operation_type='LRN', version=13)
 def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: disable=unused-argument
     size = node.attributes.get('size')
-    alpha = node.attributes.get('alpha', .0001)
-    beta = node.attributes.get('beta', .75)
-    k = node.attributes.get('bias', 1) # pylint: disable=invalid-name
+    alpha = node.attributes.get('alpha', 0.0001)
+    beta = node.attributes.get('beta', 0.75)
+    k = node.attributes.get('bias', 1)  # pylint: disable=invalid-name
 
     return OperationConverterResult(
         torch_module=nn.LocalResponseNorm(size=size, alpha=alpha, beta=beta, k=k),

--- a/onnx2torch/node_converters/lrn.py
+++ b/onnx2torch/node_converters/lrn.py
@@ -10,6 +10,7 @@ from onnx2torch.utils.common import onnx_mapping_from_node
 
 
 @add_converter(operation_type='LRN', version=13)
+@add_converter(operation_type='LRN', version=1)
 def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: disable=unused-argument
     size = node.attributes.get('size')
     alpha = node.attributes.get('alpha', 0.0001)

--- a/onnx2torch/node_converters/lrn.py
+++ b/onnx2torch/node_converters/lrn.py
@@ -1,6 +1,5 @@
 __all__ = []
 
-import torch
 from torch import nn
 
 from onnx2torch.node_converters.registry import add_converter
@@ -10,13 +9,12 @@ from onnx2torch.utils.common import OperationConverterResult
 from onnx2torch.utils.common import onnx_mapping_from_node
 
 @add_converter(operation_type='LRN', version=13)
-def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult: # pylint: disable=unused-argument
-    
+def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: disable=unused-argument
     size = node.attributes.get('size')
     alpha = node.attributes.get('alpha', .0001)
     beta = node.attributes.get('beta', .75)
-    k = node.attributes.get('size', 1)
-     
+    k = node.attributes.get('bias', 1) # pylint: disable=invalid-name
+
     return OperationConverterResult(
         torch_module=nn.LocalResponseNorm(size=size, alpha=alpha, beta=beta, k=k),
         onnx_mapping=onnx_mapping_from_node(node=node),

--- a/onnx2torch/node_converters/lrn.py
+++ b/onnx2torch/node_converters/lrn.py
@@ -1,0 +1,23 @@
+__all__ = []
+
+import torch
+from torch import nn
+
+from onnx2torch.node_converters.registry import add_converter
+from onnx2torch.onnx_graph import OnnxGraph
+from onnx2torch.onnx_node import OnnxNode
+from onnx2torch.utils.common import OperationConverterResult
+from onnx2torch.utils.common import onnx_mapping_from_node
+
+@add_converter(operation_type='LRN', version=13)
+def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult: # pylint: disable=unused-argument
+    
+    size = node.attributes.get('size')
+    alpha = node.attributes.get('alpha', .0001)
+    beta = node.attributes.get('beta', .75)
+    k = node.attributes.get('size', 1)
+     
+    return OperationConverterResult(
+        torch_module=nn.LocalResponseNorm(size=size, alpha=alpha, beta=beta, k=k),
+        onnx_mapping=onnx_mapping_from_node(node=node),
+    )

--- a/operators.md
+++ b/operators.md
@@ -63,7 +63,7 @@ Minimal tested opset version 9, maximum tested opset version 15, recommended ops
 | InstanceNormalization     | N         |                                                                                                                                                                     |
 | IsInf                     | N         |                                                                                                                                                                     |
 | IsNaN                     | N         |                                                                                                                                                                     |
-| LRN                       | N         |                                                                                                                                                                     |
+| LRN                       | Y         |                                                                                                                                                                     |
 | LSTM                      | N         |                                                                                                                                                                     |
 | LeakyRelu                 | Y         |                                                                                                                                                                     |
 | Less                      | Y         |                                                                                                                                                                     |

--- a/tests/node_converters/lrn_test.py
+++ b/tests/node_converters/lrn_test.py
@@ -1,0 +1,35 @@
+import numpy as np
+import onnx
+
+from tests.utils.common import check_onnx_model
+from tests.utils.common import make_model_from_nodes
+
+
+def _test_lrn(data: np.ndarray, alpha: float, beta: float, bias: float, size: int) -> None:
+    test_inputs = {'input_tensor': data}
+    node = onnx.helper.make_node(
+        op_type='LRN',
+        inputs=list(test_inputs),
+        outputs=['y'],
+        alpha=alpha,  # ONNX attributes are passed as regular keyword arguments.
+        beta=beta,
+        bias=bias,
+        size=size,
+    )
+
+    model = make_model_from_nodes(
+        nodes=node,
+        initializers={},
+        inputs_example=test_inputs,
+    )
+    check_onnx_model(model, test_inputs)
+
+
+def test_lrn() -> None:  # pylint: disable=missing-function-docstring
+    shape = (227, 227, 3)
+    data = np.random.random_sample(shape).astype(np.float32)
+    alpha = np.random.uniform(low=0.0, high=1.0).astype(np.float32)
+    beta = np.random.uniform(low=0.0, high=1.0).astype(np.float32)
+    bias = np.random.uniform(low=1.0, high=5.0).astype(np.float32)
+    size = np.random.randint(low=1, high=10)
+    _test_lrn(data=data, alpha=alpha, beta=beta, bias=bias, size=size)

--- a/tests/node_converters/lrn_test.py
+++ b/tests/node_converters/lrn_test.py
@@ -1,8 +1,9 @@
+from random import randrange
 import numpy as np
 import onnx
 
-from tests.utils.common import check_onnx_model
-from tests.utils.common import make_model_from_nodes
+from tests.utils.common import check_onnx_model  # pylint: disable=wrong-import-position
+from tests.utils.common import make_model_from_nodes  # pylint: disable=wrong-import-position
 
 
 def _test_lrn(data: np.ndarray, alpha: float, beta: float, bias: float, size: int) -> None:
@@ -26,10 +27,10 @@ def _test_lrn(data: np.ndarray, alpha: float, beta: float, bias: float, size: in
 
 
 def test_lrn() -> None:  # pylint: disable=missing-function-docstring
-    shape = (227, 227, 3)
+    shape = (1, 3, 227, 227)
     data = np.random.random_sample(shape).astype(np.float32)
-    alpha = np.random.uniform(low=0.0, high=1.0).astype(np.float32)
-    beta = np.random.uniform(low=0.0, high=1.0).astype(np.float32)
-    bias = np.random.uniform(low=1.0, high=5.0).astype(np.float32)
-    size = np.random.randint(low=1, high=10)
+    alpha = np.random.uniform(low=0.0, high=1.0)
+    beta = np.random.uniform(low=0.0, high=1.0)
+    bias = np.random.uniform(low=1.0, high=5.0)
+    size = randrange(start=1, stop=10, step=2)  # diameter of channels, not radius, must be odd
     _test_lrn(data=data, alpha=alpha, beta=beta, bias=bias, size=size)

--- a/tests/utils/common.py
+++ b/tests/utils/common.py
@@ -233,7 +233,6 @@ def check_onnx_model(  # pylint: disable=missing-function-docstring
     atol_torch_cpu_cuda: float = 0.0,
     atol_onnx_torch2onnx: float = 0.0,
     ignore_export_checker: bool = False,
-    cuda_available: bool = False,
     opset_version: int = 13,
 ) -> None:
     def onnx_torch_check_function(onnx_output, torch_output):  # pylint: disable=missing-function-docstring
@@ -266,25 +265,15 @@ def check_onnx_model(  # pylint: disable=missing-function-docstring
 
         return True
 
-    if cuda_available:
-        _check_onnx_model(
-            onnx_model=onnx_model,
-            onnx_inputs=onnx_inputs,
-            onnx_torch_check_function=onnx_torch_check_function,
-            torch_cpu_cuda_check_function=torch_cpu_cuda_check_function,
-            onnx_torch2onnx_check_function=onnx_torch2onnx_check_function,
-            ignore_export_checker=ignore_export_checker,
-            opset_version=opset_version,
-        )
-    else:
-        _check_onnx_model(
-            onnx_model=onnx_model,
-            onnx_inputs=onnx_inputs,
-            onnx_torch_check_function=onnx_torch_check_function,
-            onnx_torch2onnx_check_function=onnx_torch2onnx_check_function,
-            ignore_export_checker=ignore_export_checker,
-            opset_version=opset_version,
-        )
+    _check_onnx_model(
+        onnx_model=onnx_model,
+        onnx_inputs=onnx_inputs,
+        onnx_torch_check_function=onnx_torch_check_function,
+        torch_cpu_cuda_check_function=torch_cpu_cuda_check_function,
+        onnx_torch2onnx_check_function=onnx_torch2onnx_check_function,
+        ignore_export_checker=ignore_export_checker,
+        opset_version=opset_version,
+    )
 
 
 def check_torch_model(  # pylint: disable=missing-function-docstring,unused-argument

--- a/tests/utils/common.py
+++ b/tests/utils/common.py
@@ -233,6 +233,7 @@ def check_onnx_model(  # pylint: disable=missing-function-docstring
     atol_torch_cpu_cuda: float = 0.0,
     atol_onnx_torch2onnx: float = 0.0,
     ignore_export_checker: bool = False,
+    cuda_available: bool = False,
     opset_version: int = 13,
 ) -> None:
     def onnx_torch_check_function(onnx_output, torch_output):  # pylint: disable=missing-function-docstring
@@ -265,15 +266,25 @@ def check_onnx_model(  # pylint: disable=missing-function-docstring
 
         return True
 
-    _check_onnx_model(
-        onnx_model=onnx_model,
-        onnx_inputs=onnx_inputs,
-        onnx_torch_check_function=onnx_torch_check_function,
-        torch_cpu_cuda_check_function=torch_cpu_cuda_check_function,
-        onnx_torch2onnx_check_function=onnx_torch2onnx_check_function,
-        ignore_export_checker=ignore_export_checker,
-        opset_version=opset_version,
-    )
+    if cuda_available:
+        _check_onnx_model(
+            onnx_model=onnx_model,
+            onnx_inputs=onnx_inputs,
+            onnx_torch_check_function=onnx_torch_check_function,
+            torch_cpu_cuda_check_function=torch_cpu_cuda_check_function,
+            onnx_torch2onnx_check_function=onnx_torch2onnx_check_function,
+            ignore_export_checker=ignore_export_checker,
+            opset_version=opset_version,
+        )
+    else:
+        _check_onnx_model(
+            onnx_model=onnx_model,
+            onnx_inputs=onnx_inputs,
+            onnx_torch_check_function=onnx_torch_check_function,
+            onnx_torch2onnx_check_function=onnx_torch2onnx_check_function,
+            ignore_export_checker=ignore_export_checker,
+            opset_version=opset_version,
+        )
 
 
 def check_torch_model(  # pylint: disable=missing-function-docstring,unused-argument


### PR DESCRIPTION
Hi y'all,

After installing the package (through conda-forge! 🙏🏼 ), I went to convert my ONNX model, which is a modified AlexNet model (same layer architecture, just retrained with different image classes and new weights in the last layer). At this point, I realized that local response normalization was not yet implemented in onnx2torch! I looked at the relevant [pytorch docs](https://pytorch.org/docs/stable/generated/torch.nn.LocalResponseNorm.html?highlight=lrn) and [ONNX docs](http://www.xavierdupre.fr/app/mlprodict/helpsphinx/onnxops/onnx__LRN.html#id2), and it looks like both of them implement the formula directly from the [original AlexNet paper](https://proceedings.neurips.cc/paper/2012/file/c399862d3b9d6b76c8436e924a68c45b-Paper.pdf), just with slightly different argument names/order. Accordingly, I thought I might be able to handle adding a new converter for LRN.

I do want to note that I haven't added any tests for the converter, because that was beyond my Python/pytorch ability (this is all part of me learning!), but when I use my local version of the package to import my modified AlexNet model, it seeeeems not to have been mangled.

If you'd like me to work on adding the tests, I can, but it would take me some time to figure out the syntax. I would be thrilled if it ended up being very fast for you guys to add the tests yourselves.