### PR TITLE
Feat: preserve unique onnx node names

### DIFF
--- a/onnx2torch/onnx_graph.py
+++ b/onnx2torch/onnx_graph.py
@@ -28,7 +28,7 @@ class OnnxGraph:  # pylint: disable=missing-class-docstring
         unique_names = []
         counters = {}
         for node in onnx_graph_proto.node:
-            name = (f'{node.domain}/' + (node.name.replace(".", "/") or {node.op_type})).lstrip("/")
+            name = (f'{node.domain}/' + (node.name.replace(".", "/") or node.op_type)).lstrip("/")
             name_counter = counters.setdefault(name, 0)
             counters[name] += 1
             unique_names.append(f'{name}' + (f'_{name_counter}' if name_counter > 0 else ''))

--- a/onnx2torch/onnx_graph.py
+++ b/onnx2torch/onnx_graph.py
@@ -28,10 +28,10 @@ class OnnxGraph:  # pylint: disable=missing-class-docstring
         unique_names = []
         counters = {}
         for node in onnx_graph_proto.node:
-            name = f'{node.domain}_{node.op_type}'.lstrip('_')
+            name = node.name.replace(".", "/").lstrip("/")
             name_counter = counters.setdefault(name, 0)
             counters[name] += 1
-            unique_names.append(f'{name}_{name_counter}')
+            unique_names.append(f'{name}' + f'_{name_counter}' if name_counter > 1 else '')
 
         self._nodes = OrderedDict(
             (name, OnnxNode(node, unique_name=name)) for name, node in zip(unique_names, onnx_graph_proto.node)

--- a/onnx2torch/onnx_graph.py
+++ b/onnx2torch/onnx_graph.py
@@ -4,7 +4,7 @@ from types import MappingProxyType
 from typing import Mapping
 from typing import Tuple
 
-from onnx.onnx_ml_pb2 import GraphProto
+from onnx.onnx_ml_pb2 import GraphProto, NodeProto
 from onnx.onnx_ml_pb2 import ValueInfoProto
 
 from onnx2torch.onnx_node import OnnxNode

--- a/onnx2torch/onnx_graph.py
+++ b/onnx2torch/onnx_graph.py
@@ -97,4 +97,4 @@ class OnnxGraph:  # pylint: disable=missing-class-docstring
 
     @staticmethod
     def generate_node_name(node: NodeProto) -> str:
-        return (f'{node.domain}/' + (node.name.replace(".", "/") or node.op_type)).lstrip("/")
+        return (f'{node.domain}/' + (node.name.replace('.', '/') or node.op_type)).lstrip('/')

--- a/onnx2torch/onnx_graph.py
+++ b/onnx2torch/onnx_graph.py
@@ -28,10 +28,10 @@ class OnnxGraph:  # pylint: disable=missing-class-docstring
         unique_names = []
         counters = {}
         for node in onnx_graph_proto.node:
-            name = node.name.replace(".", "/").lstrip("/")
+            name = (f'{node.domain}/' + (node.name.replace(".", "/") or {node.op_type})).lstrip("/")
             name_counter = counters.setdefault(name, 0)
             counters[name] += 1
-            unique_names.append(f'{name}' + f'_{name_counter}' if name_counter > 1 else '')
+            unique_names.append(f'{name}' + (f'_{name_counter}' if name_counter > 0 else ''))
 
         self._nodes = OrderedDict(
             (name, OnnxNode(node, unique_name=name)) for name, node in zip(unique_names, onnx_graph_proto.node)

--- a/onnx2torch/onnx_graph.py
+++ b/onnx2torch/onnx_graph.py
@@ -98,4 +98,20 @@ class OnnxGraph:  # pylint: disable=missing-class-docstring
 
     @staticmethod
     def generate_node_name(node: NodeProto) -> str:
+        """Generate a torch module name from the given onnx node import it with.
+
+        Uses the ONNX node's name by default, falling back to the op_type in case the former is empty. The node's
+        domain is prepended to this.
+
+        Dots (.) are not allowed within names in torch, so they are replaced with a slash (/) instead.
+
+        Parameters
+        ----------
+        node
+            The ONNX node to create a name from.
+
+        Returns
+        -------
+        A torch-compatible module name based on the given node's properties.
+        """
         return (f'{node.domain}/' + (node.name.replace('.', '/') or node.op_type)).lstrip('/')

--- a/onnx2torch/onnx_graph.py
+++ b/onnx2torch/onnx_graph.py
@@ -4,7 +4,8 @@ from types import MappingProxyType
 from typing import Mapping
 from typing import Tuple
 
-from onnx.onnx_ml_pb2 import GraphProto, NodeProto
+from onnx.onnx_ml_pb2 import GraphProto
+from onnx.onnx_ml_pb2 import NodeProto
 from onnx.onnx_ml_pb2 import ValueInfoProto
 
 from onnx2torch.onnx_node import OnnxNode

--- a/onnx2torch/onnx_graph.py
+++ b/onnx2torch/onnx_graph.py
@@ -28,7 +28,7 @@ class OnnxGraph:  # pylint: disable=missing-class-docstring
         unique_names = []
         counters = {}
         for node in onnx_graph_proto.node:
-            name = (f'{node.domain}/' + (node.name.replace(".", "/") or node.op_type)).lstrip("/")
+            name = OnnxGraph.generate_node_name(node)
             name_counter = counters.setdefault(name, 0)
             counters[name] += 1
             unique_names.append(f'{name}' + (f'_{name_counter}' if name_counter > 0 else ''))
@@ -94,3 +94,7 @@ class OnnxGraph:  # pylint: disable=missing-class-docstring
         value_name: str,
     ) -> Tuple[OnnxNode, int]:
         return self._node_output_values[value_name]
+
+    @staticmethod
+    def generate_node_name(node: NodeProto) -> str:
+        return (f'{node.domain}/' + (node.name.replace(".", "/") or node.op_type)).lstrip("/")


### PR DESCRIPTION
Currently, each ONNX node is assigned a unique name consisting of the domain, op_type and a running counter to name the torch module with: https://github.com/ENOT-AutoDL/onnx2torch/blob/main/onnx2torch/onnx_graph.py#L29-L34

However, it can be useful to be able to infer the torch module from the onnx graph after loading it, say for example if you want to modify something specifically in the conv-layers in the head of the network. Since torch 1.13, the names of the onnx nodes are also inferred from the namescopes (see https://github.com/pytorch/pytorch/issues/75100), so being able to match that makes finding modules after a torch-onnx-torch round extremely easy.

This change replaces the previous naming scheme with one based on the onnx node names, modifying them only when and as far as necessary:
- Dots `.` are not allowed as names, so they are replaced with a slash `/`. They occur when you export e.g. a `ModuleList` or `Sequential` from torch. Colons `:` are fine and don't need handling
- If for some reason, there are duplicate node names, a running counter is appended with an underscore. This keeps the existing counter, but doesn't append anything on the first occurence to keep the name if possible. Generally, node names are required to be unique in the ONNX standard anyways, but nothing prevents you from creating a graph with duplicate names, so why not account for it anyways.
- If for some reason, the name is empty, it will use the op_type as a fallback, so basically the old behavior
- `domain` is prepended and separated by a slash, too. Not sure if that is needed, in my use-cases `domain` is empty anyways

Example screenshots from inspecting the modules after loading a cifar100 resnet:
<details>
<summary>Before:</summary>
<img src="https://user-images.githubusercontent.com/18348021/219619250-825ddb75-d920-4318-8b1d-95ba90969e74.png"/>
</details>
<details>
<summary>After:</summary>
<img src="https://user-images.githubusercontent.com/18348021/219616133-faf0afd4-7283-44d0-a47c-3221d160f796.png"/>
</details>

Also, I'm assuming the existing tests are enough to make sure this doesn't actually break things. Should I add a test to make sure it actually works as expected?

