### PR TITLE
Fix: Gemm node converter weights

### DIFF
--- a/onnx2torch/node_converters/gemm.py
+++ b/onnx2torch/node_converters/gemm.py
@@ -70,7 +70,7 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:
             if not trans_b:
                 weights = weights.T
 
-            in_features, out_features = weights.shape[0], weights.shape[1]
+            in_features, out_features = weights.shape[1], weights.shape[0]
             torch_module = nn.Linear(
                 in_features=in_features,
                 out_features=out_features,


### PR DESCRIPTION
Hey, I found a minor issue in the `Gemm` converter where the dimensions of the weights are swapped in some cases.

You can reproduce it with this cifar resnet for example:
Model file: [cifarresnet.zip](https://github.com/ENOT-AutoDL/onnx2torch/files/10883122/cifarresnet.zip)

![image](https://user-images.githubusercontent.com/18348021/222752239-cd46a07c-926e-4fb8-a46b-f28df998f904.png)

Before (current main):
```python
>>> model = onnx_to_torch("cifarresnet.onnx")
>>> model.get_submodule("Gemm_0")
Linear(in_features=100, out_features=512, bias=True)
```

After:
```python
>>> model = onnx_to_torch("cifarresnet.onnx")
>>> model.get_submodule("Gemm_0")
Linear(in_features=512, out_features=100, bias=True)
```

The way the actual weights are handled is correct as far as I can tell. This showed up in some internal torch graph modification I was doing that relied on these parameters. My guess is that these are not used much beyond initialization, so when the weights were set already, it probably didn't matter for forward passes. Either way, this fixes it also for my use-case :)