### PR TITLE
FIX: fixed export to onnx (Range)

### DIFF
--- a/onnx2torch/node_converters/range.py
+++ b/onnx2torch/node_converters/range.py
@@ -28,12 +28,12 @@ class OnnxRange(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: disabl
 
         return value
 
-    def _do_arange(
+    def _arange(
         self,
         start: Union[torch.Tensor, float, int],
         limit: Union[torch.Tensor, float, int],
         delta: Union[torch.Tensor, float, int],
-    ):
+    ) -> torch.Tensor:
         return torch.arange(
             start=self._get_scalar(start),
             end=self._get_scalar(limit),
@@ -47,7 +47,7 @@ class OnnxRange(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: disabl
         limit: Union[torch.Tensor, float, int],
         delta: Union[torch.Tensor, float, int],
     ) -> torch.Tensor:
-        forward_lambda = lambda: self._do_arange(start, limit, delta)
+        forward_lambda = lambda: self._arange(start, limit, delta)
 
         if torch.onnx.is_in_onnx_export():
             return DefaultExportToOnnx.export(forward_lambda, 'Range', start, limit, delta, {})

--- a/onnx2torch/node_converters/range.py
+++ b/onnx2torch/node_converters/range.py
@@ -10,12 +10,13 @@ from torch import nn
 from onnx2torch.node_converters.registry import add_converter
 from onnx2torch.onnx_graph import OnnxGraph
 from onnx2torch.onnx_node import OnnxNode
-from onnx2torch.utils.common import OnnxToTorchModule
 from onnx2torch.utils.common import OperationConverterResult
 from onnx2torch.utils.common import onnx_mapping_from_node
+from onnx2torch.utils.custom_export_to_onnx import DefaultExportToOnnx
+from onnx2torch.utils.custom_export_to_onnx import OnnxToTorchModuleWithCustomExport
 
 
-class OnnxRange(nn.Module, OnnxToTorchModule):  # pylint: disable=missing-class-docstring
+class OnnxRange(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: disable=missing-class-docstring
     def __init__(self):
         super().__init__()
         self.register_buffer('dummy_buffer', torch.Tensor(), persistent=False)
@@ -27,18 +28,31 @@ class OnnxRange(nn.Module, OnnxToTorchModule):  # pylint: disable=missing-class-
 
         return value
 
-    def forward(  # pylint: disable=missing-function-docstring
+    def _do_arange(
         self,
         start: Union[torch.Tensor, float, int],
         limit: Union[torch.Tensor, float, int],
         delta: Union[torch.Tensor, float, int],
-    ) -> torch.Tensor:
+    ):
         return torch.arange(
             start=self._get_scalar(start),
             end=self._get_scalar(limit),
             step=self._get_scalar(delta),
             device=self.dummy_buffer.device,
         )
+
+    def forward(  # pylint: disable=missing-function-docstring
+        self,
+        start: Union[torch.Tensor, float, int],
+        limit: Union[torch.Tensor, float, int],
+        delta: Union[torch.Tensor, float, int],
+    ) -> torch.Tensor:
+        forward_lambda = lambda: self._do_arange(start, limit, delta)
+
+        if torch.onnx.is_in_onnx_export():
+            return DefaultExportToOnnx.export(forward_lambda, 'Range', start, limit, delta, {})
+
+        return forward_lambda()
 
 
 @add_converter(operation_type='Range', version=11)


### PR DESCRIPTION
Old behavior breaks the dynamic nature of Range. After export start, limit and delta become constants. New export logic allows keeping dynamic inputs as is.
