### PR TITLE
bugfix: ReduceSumStaticAxes type correction

### DIFF
--- a/onnx2torch/node_converters/reduce.py
+++ b/onnx2torch/node_converters/reduce.py
@@ -155,7 +155,7 @@ class OnnxReduceSumStaticAxes(nn.Module, OnnxToTorchModule):  # pylint: disable=
 
             self._axes = list(range(input_tensor.dim()))
 
-        return torch.sum(input_tensor, dim=self._axes, keepdim=self._keepdims)
+        return torch.sum(input_tensor, dim=tuple(self._axes), keepdim=bool(self._keepdims))
 
 
 class OnnxReduceStaticAxes(nn.Module, OnnxToTorchModule):  # pylint: disable=missing-class-docstring

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     'onnx>=1.9.0',
     'torch>=1.8.0',
     'torchvision>=0.9.0',
+    'onnxruntime>=1.15.1',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Hello,

**Bug details:**
```
File "onnx2torch/onnx2torch/node_converters/reduce.py", line 159, in forward
    return torch.sum(input_tensor, dim=self._axes, keepdim=self._keepdims)
TypeError: sum() received an invalid combination of arguments - got (Tensor, keepdim=int, dim=list), but expected one of:
 * (Tensor input, *, torch.dtype dtype)
      didn't match because some of the keywords were incorrect: keepdim, dim
 * (Tensor input, tuple of ints dim, bool keepdim, *, torch.dtype dtype, Tensor out)
 * (Tensor input, tuple of names dim, bool keepdim, *, torch.dtype dtype, Tensor out)
 ```
**Args/Attrs to reproduce**
`input_tensor.shape`: `torch.Size([1, 8, 8, 65])`
`self._axes`: `[1, 2] <class 'list'>`
`self._keepdims`: `0 <class 'int'>`

**Solution**

My solution is a simple typecast. Only tested against my particular example.

