### PR TITLE
Bug Fix: Always index into squence-like outputs

### DIFF
--- a/onnx2torch/converter.py
+++ b/onnx2torch/converter.py
@@ -124,7 +124,7 @@ def convert(  # pylint: disable=too-many-locals, too-many-branches, too-many-sta
                 torch_input_node = torch_nodes[onnx_input_node.unique_name]
 
                 # Get only one needed output of torch_input_node by index
-                if len(onnx_input_node.output_values) > 1:
+                if len(onnx_input_node.output_values) > 1 or onnx_input_node._proto.op_type in ('If', 'Loop', 'Scan', 'SequenceMap', 'Split'):
                     index = onnx_input_node.output_values.index(value_name)
                     torch_input_node = torch_graph.call_function(getitem, args=(torch_input_node, index))
                     torch_nodes[name + '_split_output'] = torch_input_node


### PR DESCRIPTION
Some operators are intended to produce 1 or more outputs and will always return a `Sequence[torch.Tensor]`. Therefore, when `len(output_values) == 1`, the code breaks since it treated it as a single output tensor. I fix this issue by modifying the condition to index into output.

Include op types are: `['If', 'Loop', 'Scan', 'SequenceMap', 'Split']`