### PR TITLE
add recent opset_versions for transpose operation

### DIFF
--- a/onnx2torch/node_converters/transpose.py
+++ b/onnx2torch/node_converters/transpose.py
@@ -30,6 +30,10 @@ class OnnxTranspose(nn.Module, OnnxToTorchModule):  # pylint: disable=missing-cl
 
 @add_converter(operation_type='Transpose', version=1)
 @add_converter(operation_type='Transpose', version=13)
+@add_converter(operation_type='Transpose', version=21)
+@add_converter(operation_type='Transpose', version=23)
+@add_converter(operation_type='Transpose', version=24)
+@add_converter(operation_type='Transpose', version=25)
 def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: disable=unused-argument
     input_values = [node.input_values[0]]
     perm_value_name = node.input_values[1] if len(node.input_values) > 1 else None


### PR DESCRIPTION
The model conversion from onnx to coreml is failing in the onnx_to_torch Zetic's fork. Need to add version support for this opset. 

`Unacceptable Error: Converter is not implemented (OperationDescription(domain='', operation_type='Transpose', version=21))`